### PR TITLE
Support nested pathless layout routes

### DIFF
--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -67,8 +67,11 @@ export function defineConventionalRoutes(
       );
 
       let isIndexRoute = routeId.endsWith("/index");
+      let routeIdBySegment = routeId.split("/");
+      let lastSegment = routeIdBySegment[routeIdBySegment.length - 1];
+      let isLayoutRoute = lastSegment.startsWith("__");
       let fullPath = createRoutePath(routeId.slice("routes".length + 1));
-      let uniqueRouteId = (fullPath || "") + (isIndexRoute ? "?index" : "");
+      let uniqueRouteId = (fullPath || "") + (isIndexRoute ? "?index" : "") + (isLayoutRoute ? routeId : "");
 
       if (uniqueRouteId) {
         if (uniqueRoutes.has(uniqueRouteId)) {


### PR DESCRIPTION
Because pathless layouts has a uniqueRouteId being `""` this adds the whole routeId, this way nested layouts will be use the actual routeId.

Closes: #

- [ ] Docs
- [ ] Tests
